### PR TITLE
move preference getting function to `Source`

### DIFF
--- a/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt
@@ -1,26 +1,8 @@
 package eu.kanade.tachiyomi.source
 
-import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
 
 @Suppress("unused")
 interface ConfigurableSource {
-
-    /**
-     * Gets instance of [SharedPreferences] scoped to the specific source.
-     *
-     * @since extensions-lib 1.6
-     */
-    fun getSourcePreferences(): SharedPreferences = throw Exception("Stub!")
-
-    /**
-     * Gets instance of [SharedPreferences] corrisponding to the source id
-     *
-     * @parm id the source id
-     * @since extensions-lib 1.6
-     */
-    fun getSourcePreferences(id: Long): SharedPreferences = throw Exception("Stub!")
-
     fun setupPreferenceScreen(screen: PreferenceScreen)
-
 }

--- a/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt
@@ -11,7 +11,7 @@ interface ConfigurableSource {
      *
      * @since extensions-lib 1.6
      */
-    protected fun getSourcePreferences(): SharedPreferences = throw Exception("Stub!")
+    fun getSourcePreferences(): SharedPreferences = throw Exception("Stub!")
 
     /**
      * Gets instance of [SharedPreferences] corrisponding to the source id
@@ -19,7 +19,7 @@ interface ConfigurableSource {
      * @parm id the source id
      * @since extensions-lib 1.6
      */
-    protected fun getSourcePreferences(id: Long): SharedPreferences = throw Exception("Stub!")
+    fun getSourcePreferences(id: Long): SharedPreferences = throw Exception("Stub!")
 
     fun setupPreferenceScreen(screen: PreferenceScreen)
 

--- a/library/src/main/java/eu/kanade/tachiyomi/source/Source.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/Source.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.source
 
+import android.content.SharedPreferences
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -128,6 +129,21 @@ interface Source {
         ReplaceWith("getPageList"),
     )
     fun fetchPageList(chapter: SChapter): Observable<List<Page>> = throw Exception("Stub!")
+
+    /**
+     * Gets instance of [SharedPreferences] scoped to the specific source.
+     *
+     * @since extensions-lib 1.6
+     */
+    fun getSourcePreferences(): SharedPreferences = throw Exception("Stub!")
+
+    /**
+     * Gets instance of [SharedPreferences] corrisponding to the source id
+     *
+     * @parm id the source id
+     * @since extensions-lib 1.6
+     */
+    fun getSourcePreferences(id: Long): SharedPreferences = throw Exception("Stub!")
 
     object Language {
         const val MULTI = "multi"


### PR DESCRIPTION
https://jitpack.io/com/github/mihonapp/extensions-lib/main-1.4.4-gc12bde8-15/build.log
```
> Task :library:compileReleaseKotlin FAILED
e: file:///home/jitpack/build/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt:14:5 Modifier 'protected' is not applicable inside 'interface'
e: file:///home/jitpack/build/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt:22:5 Modifier 'protected' is not applicable inside 'interface'

> Task :library:compileDebugKotlin FAILED
e: file:///home/jitpack/build/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt:14:5 Modifier 'protected' is not applicable inside 'interface'
e: file:///home/jitpack/build/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt:22:5 Modifier 'protected' is not applicable inside 'interface'
```