### PR TITLE
feat: full chapter file download

### DIFF
--- a/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/ConfigurableSource.kt
@@ -1,20 +1,10 @@
 package eu.kanade.tachiyomi.source
 
-import android.content.SharedPreferences
 import androidx.preference.PreferenceScreen
 
 @Suppress("unused")
 interface ConfigurableSource {
 
     fun setupPreferenceScreen(screen: PreferenceScreen)
-
-    /**
-     * Gets instance of [SharedPreferences] scoped to the specific source.
-     * This is used to access source-specific preferences, including full chapter download settings.
-     *
-     * @since extensions-lib 1.5
-     * @return SharedPreferences instance for this source
-     */
-    fun sourcePreferences(): SharedPreferences = throw Exception("Stub!")
 
 }

--- a/library/src/main/java/eu/kanade/tachiyomi/source/Source.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/Source.kt
@@ -7,12 +7,6 @@ import okhttp3.Response
 import rx.Observable
 
 /**
- * Preference key for enabling full chapter downloads in extensions.
- * Extensions should use this key when adding a boolean preference for full chapter downloads.
- */
-const val FULL_CHAPTER_DOWNLOAD_PREF_KEY = "full_chapter_download_enabled"
-
-/**
  * A basic interface for creating a source. It could be an online source, a local source, etc...
  */
 @Suppress("unused")
@@ -66,39 +60,4 @@ interface Source {
         ReplaceWith("getChapterList"),
     )
     fun fetchChapterList(manga: SManga): Observable<List<SChapter>> = throw Exception("Stub!")
-}
-
-/**
- * A source that supports downloading complete chapters as archive files (e.g., CBZ).
- * This is an optional interface that sources can implement to provide more efficient
- * chapter downloads when the source hosts complete chapter files.
- *
- * @since extensions-lib 1.6
- */
-interface FullChapterSource : Source {
-
-    /**
-     * Indicates whether this source supports downloading complete chapters as archive files.
-     * This should return true only if the source can provide complete chapter files
-     * (e.g., CBZ, ZIP) instead of individual page images.
-     *
-     * @since extensions-lib 1.6
-     * @return true if the source supports full chapter downloads, false otherwise
-     */
-    fun supportsFullChapterDownload(): Boolean = false
-
-    /**
-     * Downloads a complete chapter as an archive file (e.g., CBZ).
-     * This method is only called if [supportsFullChapterDownload] returns true
-     * and the user has enabled full chapter downloads in the source's preferences.
-     *
-     * The returned Response should contain the complete chapter archive file.
-     * The Content-Type should be appropriate for the archive format (e.g., application/zip).
-     *
-     * @since extensions-lib 1.6
-     * @param chapter the chapter to download as a complete archive
-     * @return Response containing the complete chapter archive file
-     * @throws Exception if the chapter cannot be downloaded as a complete archive
-     */
-    suspend fun getFullChapter(chapter: SChapter): Response = throw Exception("Stub!")
 }

--- a/library/src/main/java/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -335,37 +335,16 @@ abstract class HttpSource : CatalogueSource {
     // ===== Full Chapter Download Support =====
 
     /**
-     * Indicates whether this source supports downloading complete chapters as archive files.
-     * Override this method to return true if your source can provide complete chapter files.
-     *
-     * @since extensions-lib 1.6
-     * @return true if the source supports full chapter downloads, false otherwise
-     */
-    open fun supportsFullChapterDownload(): Boolean = false
-
-    /**
-     * Returns the request for downloading a complete chapter as an archive file.
-     * Override this method if you need to customize the request (e.g., different headers, POST method).
-     * This method is only called if [supportsFullChapterDownload] returns true.
-     *
-     * @since extensions-lib 1.6
-     * @param chapter the chapter to download as a complete archive
-     * @return Request for downloading the complete chapter archive
-     */
-    protected open fun fullChapterRequest(chapter: SChapter): Request {
-        throw Exception("Stub!")
-    }
-
-    /**
-     * Downloads a complete chapter as an archive file.
-     * This default implementation uses [fullChapterRequest] to create the request.
-     * Override this method if you need custom download logic.
+     * Downloads a complete chapter as an archive file (e.g., CBZ).
+     * Override this method if your source can provide complete chapter files
+     * instead of individual page images.
      *
      * @since extensions-lib 1.6
      * @param chapter the chapter to download as a complete archive
      * @return Response containing the complete chapter archive file
+     * @throws UnsupportedOperationException if the source doesn't support full chapter downloads
      */
     open suspend fun getFullChapter(chapter: SChapter): Response {
-        throw Exception("Stub!")
+        throw UnsupportedOperationException("Source does not support full chapter downloads")
     }
 }


### PR DESCRIPTION
This PR, alongside its [sister mihon PR](https://github.com/mihonapp/mihon/pull/2431), aims to allow extensions to use an alternate download strategy (dubbed full chapter download) where whole cbz files are downloaded instead of the traditional page-by-page download.

Here, I added stubs for the full chapter download API.

This feature is non-breaking, as it needs to be enabled via user preference.

I have tested this feature with various files hosted on my Suwayomi instance by running a local build of the app and the extension on my device.

Again, as this is my first attempt at contribution, feel free to point out any issue with it (be it code style, code architecture, or others). Feedback is greatly appreciated.