### PR TITLE
Status for chapters require paid/premium account

### DIFF
--- a/library/api/library.api
+++ b/library/api/library.api
@@ -335,11 +335,13 @@ public abstract interface class eu/kanade/tachiyomi/source/model/SChapter {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getScanlator ()Ljava/lang/String;
 	public abstract fun getUrl ()Ljava/lang/String;
+	public abstract fun getIsPremium ()Z
 	public abstract fun setChapter_number (F)V
 	public abstract fun setDate_upload (J)V
 	public abstract fun setName (Ljava/lang/String;)V
 	public abstract fun setScanlator (Ljava/lang/String;)V
 	public abstract fun setUrl (Ljava/lang/String;)V
+	public abstract fun setIsPremium (Z)V
 }
 
 public final class eu/kanade/tachiyomi/source/model/SChapter$Companion {

--- a/library/src/main/java/eu/kanade/tachiyomi/source/model/SChapter.kt
+++ b/library/src/main/java/eu/kanade/tachiyomi/source/model/SChapter.kt
@@ -15,6 +15,8 @@ interface SChapter {
 
     var scanlator: String?
 
+    var isPremium: Boolean
+
     companion object {
         fun create(): SChapter = throw Exception("Stub!")
     }


### PR DESCRIPTION
Although `note` can be used to let user know of lock status, but that won't help app avoid trying to download and pop an error message.